### PR TITLE
Fix portfolio management

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,19 @@ __Use JACT at your own risk__
 GDAX trading bot. Add your own buy/sell strategies or use the ones provided. A custom strategy need only export a function that returns `SHORT`, `LONG` and be put in the `lib/strategies` directory. Technical indicators are provided by [technicalIndicators](https://github.com/anandanand84/technicalindicators). Up-to-date historical data (past 350 periods) can be retreived with `HistoricDataProvider.get()` and used in indicator calculations.
 
 #### Trading
-JACT will always place limit orders on your side of the spread to avoid taker fees. If your strategy signals a LONG or SHORT position, JACT will continue placing best possible orders until the position is fully filled (based on `config.maxFunds` and/or your account balance).
+JACT will always place limit orders on your side of the spread to avoid taker fees.
 
-For example if the strategy signals LONG for 1 BTC, but only gets partially filled for .5 BTC or gets cancelled. Then, JACT will open a new order for the remaining size(.5) at the current best bid. It will continue doing this until the full 1 BTC position is filled.
+If your strategy signals a LONG position, JACT will try to place an order at the current best_bid. However, if it is canceled, or partially filled JACT will not open more orders to fill the remaining size of the original order. This is done to manage slippage.
+
+Conversely, If your strategy signals SHORT, JACT will continue placing best possible orders until the position is fully filled and closed.
+
+For example: the strategy signals LONG to buy 1 BTC, but only gets partially filled for .5 BTC. JACT will wait for a SHORT signal. On SHORT, it will open a sell order for .5 BTC. If that order is canceled or partially filled, it will continue opening orders at best_ask, every minute, until the position is fully sold. _*This may change in the future*_
 
 #### Stop Loss
 JACT will constantly monitor the current price and compare it against any open position. If the current price falls below the `config.stopLoss` percentage it will immediately place a market sell order (has taker fee)
 
 #### Backtesting
-JACT has a basic backtesting feature. You can test your strategy against historical data of the dates you provide in `config.backtest.start_date` & `config.backtest.end_date` It does not take into account slippage, fees, or order averaging.
+JACT has a basic backtesting feature. You can test your strategy against historical data of the dates you provide in `config.backtest.start_date` & `config.backtest.end_date`. Additionally, if you provide a `config.backtest.slippage`, each completed position's net will be minimized by the provided percentage to simulate slippage in real market conditions.
 
 ### How to: Trade
 _*JACT is in early development. You may experience bugs. TRADE AT YOUR OWN RISK*
@@ -28,7 +32,6 @@ _*Backtesting is an early feature. You may experience bugs*
 - configure `config.yaml` _*see sample.config.yaml*_
 - `npm run backtest`
 
-_*test coverage is still in progress*_
 ### Todo
 1. Write reports to CSV
 2. Add more strategies
@@ -41,6 +44,7 @@ Please link to or create an issue for any pull-request you plan to submit as wel
 Run tests with
 - `npm test`
 
+_*test coverage is still in progress*_
 ===============
 
 If you've enjoyed JACT, feel free to throw me some change:

--- a/lib/BacktestBot.js
+++ b/lib/BacktestBot.js
@@ -5,8 +5,9 @@ const HistoricDataProvider = require('./HistoricDataProvider')
 const BacktestDataProvider = require('./BacktestDataProvider')
 
 const ProgressBar = require('ascii-progress');
-const notifier = require('node-notifier');
+const uuid = require('uuid/v1')
 
+// @TODO add slippage
 class BacktestBot {
     constructor({
         strategy,
@@ -93,7 +94,7 @@ class BacktestBot {
 
         if (this.manager.shouldTriggerStop(BacktestDataProvider.current()[4])) {
             this.shortPosition()
-        } if (signal == 'LONG') {
+        } else if (signal == 'LONG') {
             this.longPosition()
         } else if (signal == 'SHORT') {
             this.shortPosition()
@@ -134,17 +135,20 @@ class BacktestBot {
         }
 
         // kind of makes a best-case scenario assumption here (not ideal)
-        let best_bid = BacktestDataProvider.current()[4] // low
+        let best_bid = BacktestDataProvider.current()[4]
         let params = {
+            order_id: uuid(),
             side: 'buy',
             size: this.manager.getOrderSize(best_bid),
-            price: best_bid
+            price: best_bid,
+            remaining_size: 0,
+            reason: 'filled'
         }
 
-        this.manager.openPosition(params)
-        params.remaining_size = 0
-        this.manager.updatePosition(params)
-        this.manager.addFilled(params)
+        // mock the feed
+        this.openHandler(params)
+        this.matchHandler(params)
+        this.doneHandler(params)
     }
 
     /**
@@ -159,17 +163,20 @@ class BacktestBot {
         }
         
         // kind of makes a best-case scenario assumption here
-        let best_ask = BacktestDataProvider.current()[4] // high
+        let best_ask = BacktestDataProvider.current()[4]
         let params = {
+            order_id: uuid(),
             side: 'sell',
             size: position.size,
-            price: best_ask
+            price: best_ask,
+            remaining_size: 0,
+            reason: 'filled'
         }
 
-        this.manager.closePosition(params)
-        params.remaining_size = 0
-        this.manager.updatePosition(params)
-        this.manager.addFilled(params)
+        // mock the feed
+        this.openHandler(params)
+        this.matchHandler(params)
+        this.doneHandler(params)
     }
 
     /**
@@ -187,11 +194,57 @@ class BacktestBot {
         console.log('>> Backtest complete.\n')
         console.log(this.manager.info())
         console.log('\n')
-        notifier.notify({
-            title: 'JACT',
-            message: 'Backtest complete!'
-        });
         process.exit()
+    }
+
+    /**
+     * Order open on book
+     * The order is now open on the order book. This message will only be sent for orders which are not fully filled immediately.remaining_size will indicate how much of the order is unfilled and going on the book.
+     * 
+     * @param {*} data 
+     */
+    openHandler(data) {
+        this.manager.addOpen(data)
+    }
+
+    /**
+     * When a trade is matched(exchanged)
+     */
+    matchHandler(data) {
+
+        if (this.manager.getPosition()) {
+            this.manager.updatePosition(data)
+        } else {
+            this.manager.openPosition(data)
+        }
+
+        // remove a specific order by id
+        data.maker_order_id = data.order_id
+        this.manager.removeOpen(data.maker_order_id)
+        this.manager.addFilled(data)
+    }
+
+    /**
+     * Order has been completed from the books
+     * Sent for all orders for which there was a received message
+     * 
+     * @param {*} data 
+     */
+    doneHandler(data) {
+        let remainingSize = parseFloat(data.remaining_size)
+        if (
+            (data.reason == 'canceled' && data.side == 'sell') ||
+            (data.reason == 'filled' && data.side == 'sell' && remainingSize !== 0)
+        ) {
+            this.placeOrder({
+                side: data.side,
+                size: remainingSize,
+                price: BacktestDataProvider.state().best_ask, //for now only sells open new orders
+                post_only: true,
+                time_in_force: 'GTT',
+                cancel_after: 'min'
+            })
+        }
     }
 }
 module.exports = BacktestBot

--- a/lib/CandleProvider.js
+++ b/lib/CandleProvider.js
@@ -1,8 +1,10 @@
 const moment = require('moment')
 const _toArray = require('lodash/toArray')
+const _cloneDeep = require('lodash/cloneDeep')
 const FeedService = require('./FeedService')
+const config = require('./config')
 
-let data = {
+let defaults = {
     time: null,
     low: null,
     high: null,
@@ -14,10 +16,18 @@ let data = {
     side: null
 }
 
+let data = _cloneDeep(defaults)
+
+let candleStart = null
+
 let hasUpdated = false
 
 const state = () => {
     return data
+}
+
+const reset = () => {
+    data = _cloneDeep(defaults)
 }
 
 /**
@@ -35,15 +45,31 @@ const toArray = () => {
  * @param {Object} realtimeData 
  * @return void
  */
+
 const update = (realtimeData) => {
+    let time = moment(realtimeData.time)
+
+    if (!candleStart) {
+        candleStart = time
+    }
+
+    if (time.diff(candleStart, 'seconds') >= config.granularity) {
+        reset()
+        candleStart = time
+    }
+
+    data.time = time.unix()
     let price = parseFloat(realtimeData.price)
 
     data.close = price
+    data.best_ask = parseFloat(realtimeData.best_ask)
+    data.best_bid = parseFloat(realtimeData.best_bid)
+    data.side = realtimeData.side
 
     if (!data.open) {
         data.open = price
     }
-    data.time = moment(realtimeData.time).unix()
+    
 
     if (!data.low || (data.low && price < data.low)) {
         data.low = price
@@ -56,10 +82,6 @@ const update = (realtimeData) => {
     } else {
         data.volume += parseFloat(realtimeData.last_size)
     }
-
-    data.best_ask = parseFloat(realtimeData.best_ask)
-    data.best_bid = parseFloat(realtimeData.best_bid)
-    data.side = realtimeData.side
     
     hasUpdated = true
 }
@@ -75,4 +97,4 @@ const hasData = () => {
 
 FeedService.subscribe('ticker', update.bind(this))
 
-module.exports = {state, update, toArray, hasData}
+module.exports = {state, update, toArray, hasData, reset}

--- a/lib/FeedService.js
+++ b/lib/FeedService.js
@@ -57,7 +57,7 @@ const processMessage = (data) => {
  * @return void
  */
 const processError = (error) => {
-    console.log(`>> Error: ${error}\n`)
+    console.log(`>> Websocket Error: ${error}\n`)
     websocket.socket.close()
 }
 

--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -36,6 +36,7 @@ class PortfolioManager {
             }
             let remainingSize = this.position.size - size
             this.position.sell_price += price * size
+            this.position.remaining_size = remainingSize
             if (remainingSize == 0) {
                 this.position.sell_price = this.position.sell_price / this.position.size
                 this.completePosition()
@@ -51,6 +52,7 @@ class PortfolioManager {
     openPosition(orderParams) {
         this.position = {
             size: orderParams.size,
+            remaining_size: orderParams.size,
             signal_buy_price: orderParams.price,
             buy_price: orderParams.price,
             signal_sell_price: null,
@@ -100,12 +102,11 @@ class PortfolioManager {
     }
 
     shouldTriggerStop(price) {
-        // if sell order side then we are already in progress on selling
-        if (!this.position || this.position.side == 'sell') {
+        if (!this.position) {
             return false
         }
 
-        return price <= (this.position.price - (this.options.stopLoss * this.position.price))
+        return price <= (this.position.buy_price - (this.options.stopLoss * this.position.buy_price))
     }
 
     getTotals() {

--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -49,12 +49,12 @@ class PortfolioManager {
     /**
      * Open a position, a long order has been placed
      */
-    openPosition(orderParams) {
+    openPosition(data) {
         this.position = {
-            size: orderParams.size,
-            remaining_size: orderParams.size,
-            signal_buy_price: orderParams.price,
-            buy_price: orderParams.price,
+            size: data.size,
+            remaining_size: data.size,
+            signal_buy_price: data.price,
+            buy_price: data.price, // @todo could change if adjusted long orders become allowed
             signal_sell_price: null,
             sell_price: 0,
             net: 0,
@@ -68,25 +68,47 @@ class PortfolioManager {
      * then reset the position
      */
     completePosition() {
-        this.position.net = ((this.position.sell_price * this.position.size) - (this.position.buy_price * this.position.size))
+        let net = ((this.position.sell_price * this.position.size) - (this.position.buy_price * this.position.size))
+        this.position.net = this.options.backtest.slippage ? net - (net * this.options.backtest.slippage) : net
         this.position.percent = (this.position.sell_price / this.position.buy_price) - 1
-        this.position.slippage = ((this.position.signal_sell_price / this.position.signal_buy_price) - 1) - this.position.percent
+        this.position.slippage = this.options.backtest.slippage ?
+            this.options.backtest.slippage :
+            ((this.position.signal_sell_price / this.position.signal_buy_price) - 1) - this.position.percent
         this.completed.push(this.position)
+        // @TODO fetch this from gdax again
+        // update the account amount after complete positions
+        this.usdAccount.currency += this.position.net 
         this.resetPosition()
     }
 
+    /**
+     * Reset position stats
+     */
     resetPosition() {
         this.position = null
     }
 
+    /**
+     * Get the current position
+     */
     getPosition() {
         return cloneDeep(this.position)
     }
 
+    /**
+     * Add an open order
+     * 
+     * @param {Object} data 
+     */
     addOpen(data) {
         this.open.push(data)
     }
 
+    /**
+     * Get an open order by id or the last
+     * 
+     * @param {String} id 
+     */
     getOpen(id) {
         if (!id) {
             return this.open[this.open.length - 1]
@@ -94,6 +116,11 @@ class PortfolioManager {
         return find(this.open, {order_id: id})
     }
 
+    /**
+     * Remove an open order by ID
+     * 
+     * @param {String} id 
+     */
     removeOpen(id) {
         if (!id) {
             this.open.pop()
@@ -101,6 +128,11 @@ class PortfolioManager {
         remove(this.open, o => o.order_id == id)
     }
 
+    /**
+     * If passed price triggers a stop loss market sell
+     * 
+     * @param {Number} price 
+     */
     shouldTriggerStop(price) {
         if (!this.position) {
             return false
@@ -109,6 +141,9 @@ class PortfolioManager {
         return price <= (this.position.buy_price - (this.options.stopLoss * this.position.buy_price))
     }
 
+    /**
+     * Get the totals of the completed positions
+     */
     getTotals() {
         return {
             usd: this.completed.reduce((acc, position) => acc += position.net, 0),
@@ -116,22 +151,37 @@ class PortfolioManager {
         }
     }
 
+    /**
+     * Get the average of all losing trades
+     */
     getAvgLoss() {
         let losses = this.completed.filter(position => position.net < 0)
+        if (!losses.length) {
+            return {}
+        }
         return {
             usd: losses.reduce((acc, position) => acc += position.net, 0) / losses.length,
             percent: losses.reduce((acc, position) => acc += position.percent , 0) / losses.length
         }
     }
 
+    /**
+     * Get the average of all winning trades
+     */
     getAvgWin() {
         let wins = this.completed.filter(position => position.net > 0)
+        if (!wins.length) {
+            return {}
+        }
         return {
             usd: wins.reduce((acc, position) => acc += position.net, 0) / wins.length,
             percent: wins.reduce((acc, position) => acc += position.percent, 0) / wins.length
         }
     }
 
+    /**
+     * Calculate the average slippage of all orders
+     */
     getAvgSlippage() {
         let completed = this.completed
         return completed.reduce((acc, position) => acc += position.slippage, 0) / completed.length
@@ -161,7 +211,6 @@ class PortfolioManager {
      * @param {Float} price 
      */
     getOrderSize(price) {
-        // @TODO bug here, we never update the account amount after completed positions
         let fixedDecimalMax = 8
         return (this.getFundingAmount() / price).toFixed(fixedDecimalMax)
     }
@@ -172,8 +221,7 @@ class PortfolioManager {
      * @param {String} product | 'USD', 'LTC', 'BTC'
      */
     getFundingAmount() {
-        // @TODO get transaction fee for product
-        let amount = this.usdAccount.available * .95
+        let amount = this.usdAccount.available
         return amount > this.options.maxFunds ? this.options.maxFunds : amount
     }
 }

--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -208,7 +208,7 @@ class PortfolioManager {
      * Gets the order size for the provided product based on available funding
      * 
      * @param {String} product | 'USD', 'LTC', 'BTC'
-     * @param {Float} price 
+     * @param {Float} price
      */
     getOrderSize(price) {
         let fixedDecimalMax = 8

--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -1,5 +1,6 @@
 const find = require('lodash/find')
 const cloneDeep = require('lodash/cloneDeep')
+const remove = require('lodash/remove')
 
 class PortfolioManager {
     constructor(accounts, options) {
@@ -8,9 +9,9 @@ class PortfolioManager {
         this.options = options
 
         this.position = null
-        this.openOrder = null
+        this.completed = []
+        this.open = []
         this.filled = []
-        this.received = []
     }
 
     addFilled(data) {
@@ -21,45 +22,58 @@ class PortfolioManager {
         return cloneDeep(this.filled)
     }
 
-    addReceived(data) {
-        this.received.push(data)
-    }
-
-    getLastReceived() {
-        return this.received[this.received.length - 1]
-    }
-
+    /**
+     * Update a position props
+     * 
+     * @param {Object} data 
+     */
     updatePosition(data) {
-        if (!this.position) {
-            return
-        }
-        if (this.position.side == 'sell') {
-            this.position.size -= this.position.size_to_fill - data.remaining_size
-            if (this.position.size == 0) {
-                this.position = null
+        let size = parseFloat(data.size)
+        let price = parseFloat(data.price)
+        if (data.side == 'sell') {
+            if (!this.position.signal_sell_price) {
+                this.position.signal_sell_price = price
             }
-        } else {
-            let fillSize = this.position.size_to_fill - data.remaining_size
-            this.position.size += fillSize
-            this.position.price = this.position.price + (fillSize * data.price) / this.position.size
+            let remainingSize = this.position.size - size
+            this.position.sell_price += price * size
+            if (remainingSize == 0) {
+                this.position.sell_price = this.position.sell_price / this.position.size
+                this.completePosition()
+                return
+            }
+            this.position.sell_price = this.position.sell_price / (this.position.size - remainingSize)
         }
     }
 
+    /**
+     * Open a position, a long order has been placed
+     */
     openPosition(orderParams) {
         this.position = {
-            size_to_fill: orderParams.size,
-            size: 0,
-            price: 0,
-            side: orderParams.side || 'buy'
+            size: orderParams.size,
+            signal_buy_price: orderParams.price,
+            buy_price: orderParams.price,
+            signal_sell_price: null,
+            sell_price: 0,
+            net: 0,
+            percent: 0,
+            slippage: 0
         }
     }
 
-    closePosition() {
-        this.position.size_to_fill = this.position.size
-        this.position.side = 'sell'
+    /**
+     * Calculate final percentages and append to the filled positions
+     * then reset the position
+     */
+    completePosition() {
+        this.position.net = ((this.position.sell_price * this.position.size) - (this.position.buy_price * this.position.size))
+        this.position.percent = (this.position.sell_price / this.position.buy_price) - 1
+        this.position.slippage = ((this.position.signal_sell_price / this.position.signal_buy_price) - 1) - this.position.percent
+        this.completed.push(this.position)
+        this.resetPosition()
     }
 
-    cancelPosition() {
+    resetPosition() {
         this.position = null
     }
 
@@ -67,16 +81,22 @@ class PortfolioManager {
         return cloneDeep(this.position)
     }
 
-    addOpenOrder(data) {
-        this.openOrder = data
+    addOpen(data) {
+        this.open.push(data)
     }
 
-    getOpenOrder() {
-        return this.openOrder
+    getOpen(id) {
+        if (!id) {
+            return this.open[this.open.length - 1]
+        }
+        return find(this.open, {order_id: id})
     }
 
-    removeOpenOrder() {
-        this.openOrder = null
+    removeOpen(id) {
+        if (!id) {
+            this.open.pop()
+        }
+        remove(this.open, o => o.order_id == id)
     }
 
     shouldTriggerStop(price) {
@@ -88,106 +108,32 @@ class PortfolioManager {
         return price <= (this.position.price - (this.options.stopLoss * this.position.price))
     }
 
-    /**
-     * Calculates the net amount from filled trades
-     */
-    getNetMargin() {
-        return this.getFilled().reduce((acc, trade) => {
-            if (trade.side == 'buy') {
-                return acc - (trade.price * trade.size)
-            } else {
-                return acc + (trade.price * trade.size)
-            }
-        }, 0)
-    }
-
-    getAvgs() {
-        let filled = this.getFilled()
-        let buys = filled.filter(trade => trade.side == 'buy')
-        let sells = filled.filter(trade => trade.side == 'sell')
-
-        let combinedBuys = []
-        let combinedSells = []
-        let temp = 0
-        let combinedSize = 0
-
-        // get buy averages
-        buys.forEach(buy => {
-            let size = parseFloat(buy.size)
-            let price = parseFloat(buy.price)
-            temp += price * size
-            combinedSize += parseFloat(size)
-            if (parseFloat(buy.remaining_size) == 0) {
-                if (combinedSize == size) {
-                    combinedBuys.push(temp)
-                } else {
-                    combinedBuys.push(temp / combinedSize)
-                }
-                temp = 0
-                combinedSize = 0
-            }
-        })
-
-        // get sell averages
-        sells.forEach(sell => {
-            let size = parseFloat(sell.size)
-            let price = parseFloat(sell.price)
-            temp += price * size
-            combinedSize += parseFloat(size)
-            if (parseFloat(sell.remaining_size) == 0) {
-                if (combinedSize == size) {
-                    combinedSells.push(temp)
-                } else {
-                    combinedSells.push(temp / combinedSize)
-                }
-                temp = 0
-                combinedSize = 0
-            }
-        })
-
+    getTotals() {
         return {
-            sells: combinedSells, buys: combinedBuys
+            usd: this.completed.reduce((acc, position) => acc += position.net, 0),
+            percent: this.completed.reduce((acc, position) => acc += position.percent, 0),
         }
     }
 
-    /**
-     * Gets the average price of winning trades
-     * 
-     * @return {Integer}
-     */
-    getAvgWin() {
-        let avg = this.getAvgs()
-
-        // get total win avg
-        let tradeGains = []
-        avg.sells.forEach(sellAvg => {
-            avg.buys.forEach(buyAvg => {
-                if (sellAvg > buyAvg) {
-                    tradeGains.push(sellAvg - buyAvg)
-                }
-            })
-        })
-
-        return (tradeGains.reduce((acc, gain) => acc + gain, 0) / tradeGains.length) || 0
+    getAvgLoss() {
+        let losses = this.completed.filter(position => position.net < 0)
+        return {
+            usd: losses.reduce((acc, position) => acc += position.net, 0) / losses.length,
+            percent: losses.reduce((acc, position) => acc += position.percent , 0) / losses.length
+        }
     }
 
-    /**
-     * Gets the average price of losing trades
-     * 
-     * @return {Integer}
-     */
-    getAvgLoss() {
-        let avg = this.getAvgs()
-        let tradeLosses = []
-        avg.sells.forEach(sellAvg => {
-            avg.buys.forEach(buyAvg => {
-                if (sellAvg < buyAvg) {
-                    tradeLosses.push(buyAvg - sellAvg)
-                }
-            })
-        })
+    getAvgWin() {
+        let wins = this.completed.filter(position => position.net > 0)
+        return {
+            usd: wins.reduce((acc, position) => acc += position.net, 0) / wins.length,
+            percent: wins.reduce((acc, position) => acc += position.percent, 0) / wins.length
+        }
+    }
 
-        return (tradeLosses.reduce((acc, gain) => acc + gain, 0) / tradeLosses.length) || 0
+    getAvgSlippage() {
+        let completed = this.completed
+        return completed.reduce((acc, position) => acc += position.slippage, 0) / completed.length
     }
 
     /**
@@ -200,24 +146,11 @@ class PortfolioManager {
         return {
             currentPosition: this.getPosition(),
             totalTrades: this.getFilled().length,
-            avgWin: {
-                usd: this.getAvgWin(),
-            },
-            avgLoss: {
-                usd: this.getAvgLoss(),
-            },
-            netProfit: {
-                usd: this.getNetMargin(),
-                percent: this.getPercentMargin()
-            }
+            avgSlippage: this.getAvgSlippage(),
+            avgWin: this.getAvgWin(),
+            avgLoss: this.getAvgLoss(),
+            netProfit: this.getTotals()
         }
-    }
-
-    /**
-     * Calculates the percentage gain from completed trades
-     */
-    getPercentMargin() {
-        return this.getNetMargin() / this.getFundingAmount()
     }
 
     /**
@@ -227,6 +160,7 @@ class PortfolioManager {
      * @param {Float} price 
      */
     getOrderSize(price) {
+        // @TODO bug here, we never update the account amount after completed positions
         let fixedDecimalMax = 8
         return (this.getFundingAmount() / price).toFixed(fixedDecimalMax)
     }
@@ -237,7 +171,7 @@ class PortfolioManager {
      * @param {String} product | 'USD', 'LTC', 'BTC'
      */
     getFundingAmount() {
-        // using 100% of available wallet sometimes fails "insufficient funds" because there's no overhead for the transaction fee
+        // @TODO get transaction fee for product
         let amount = this.usdAccount.available * .95
         return amount > this.options.maxFunds ? this.options.maxFunds : amount
     }

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -9,8 +9,6 @@ let Spinner = require('cli-spinner').Spinner
 let spinner = new Spinner('waiting... %s')
 spinner.setSpinnerString(0);
 
-const notifier = require('node-notifier');
-
 // @todo maybe use 'match' event to manager.updatePosition() to split up logic
 // @todo need better error handling and logging
 // @todo orderPlaced is not always working
@@ -26,8 +24,9 @@ class TraderBot {
 
         this.tradeInterval = null
         this.orderPlaced = false
-        this.canceledRetries = 0
-        this.maxRetries = 1
+
+        this.tickerUpdates = 0
+        this.tickerUpdatesMax = 10
     }
 
     /**
@@ -38,8 +37,8 @@ class TraderBot {
      */
     startTrading() {
         console.log(`>> Trading ${this.options.product} every ${this.options.granularity} seconds with ${this.options.strategy} strategy.\n`)
-        FeedService.subscribe('received', this.receivedHandler.bind(this))
         FeedService.subscribe('open', this.openHandler.bind(this))
+        FeedService.subscribe('match', this.matchHandler.bind(this))
         FeedService.subscribe('done', this.doneHandler.bind(this))
         this.trade()
     }
@@ -94,7 +93,7 @@ class TraderBot {
      * @return void
      */
     longPosition() {
-        if (this.manager.getOpenOrder()) {
+        if (this.manager.getOpen()) {
             console.log(`>> Signal LONG, but there is an open order.\n`)
             return
         }
@@ -113,7 +112,6 @@ class TraderBot {
             cancel_after: 'min'
         }
 
-        this.manager.openPosition(params)
         this.placeOrder(params)
     }
 
@@ -123,7 +121,7 @@ class TraderBot {
      * @return void
      */
     shortPosition() {
-        if (this.manager.getOpenOrder()) {
+        if (this.manager.getOpen()) {
             console.log(`>> Signal SHORT, but there is an open order.\n`)
             return
         }
@@ -142,7 +140,6 @@ class TraderBot {
             time_in_force: 'GTT',
             cancel_after: 'min'
         })
-        this.manager.closePosition()
     }
 
     /**
@@ -153,12 +150,7 @@ class TraderBot {
      */
     placeOrder(options = {}) {
         if (!options.side || !options.size) {
-            console.log('=========DEBUG==========');
-            console.log(`side: '${options.side}' and size: '${options.size}' are required.`)
-            console.log(CandleProvider.state())
-            console.log(this.manager.getPosition())
-            console.log(this.manager.info())
-            console.log('=========DEBUG==========\n');
+            console.log(`side: '${options.side}' and size: '${options.size}' are required. No order placed.`)
             return
         }
 
@@ -171,7 +163,8 @@ class TraderBot {
                 }
                 if (data.status == 'rejected' && this.manager.getPosition()) {
                     // rejected LONG orders out of sync with position in the manager so cancel any open position
-                    this.manager.cancelPosition()
+                    // this.manager.resetPosition()
+                    // @deprecated
                 }
             } catch (err) {
                 this.orderPlaced = false
@@ -189,16 +182,42 @@ class TraderBot {
     }
 
     /**
-     * Order Received
-     * @param {*} data 
+     * @TODO Manually cancel an order
+     * 
+     * @param {String} orderId 
      */
-    receivedHandler(data) {
-        if (!this.orderPlaced) {
-            return
+    // cancelOrder(orderId) {
+    //     // @todo only if there's an open order
+
+    //     async function cancelOrderAsync(id) {
+    //         try {
+    //             const data = await gdax[opts.side](opts).catch(err => { throw new Error(err) })
+    //             if (data.message) {
+    //                 throw new Error(data.message)
+    //             }
+    //             this.orderPlaced = false
+    //         } catch (err) {
+    //             this.orderPlaced = false
+    //             console.log(`>> ${err}\n`)
+    //         }
+    //     }
+
+    //     cancelOrderAsync(orderId)
+    // }
+
+    /**
+     * ticker update
+     * used to cancel/place new orders every few orderbook changes
+     * 
+     * @param {Object} data
+     * @return null
+     */
+    tickerHandler(data) {
+        this.tickerUpdates++
+        if (this.tickerUpdates >= this.tickerUpdatesMax) {
+            // cancel any open order, place a new one
+            this.tickerUpdates = 0
         }
-        spinner.stop(true)
-        this.manager.addReceived(data)
-        console.log(`>> #${data.order_id}: received.`)
     }
 
     /**
@@ -211,76 +230,59 @@ class TraderBot {
         if (!this.orderPlaced) {
             return
         }
-        this.manager.addOpenOrder(data)
+        this.manager.addOpen(data)
         console.log(`>> #${data.order_id}: open.`)
+    }
+
+    /**
+     * When a trade is matched(exchanged)
+     */
+    matchHandler(data) {
+        if (!this.orderPlaced) {
+            return
+        }
+
+        if (this.manager.getPosition()) {
+            this.manager.updatePosition(data)
+        } else {
+            this.manager.openPosition(data)
+        }
+
+        // remove a specific order by id
+        this.manager.removeOpen(data.maker_order_id)
+        this.manager.addFilled(data)
     }
 
     /**
      * Order has been completed from the books
      * Sent for all orders for which there was a received message
      * 
-     * @todo canceled order retries should only retry once.
-     * @todo partial fills should try until all the way filled
      * @param {*} data 
      */
     doneHandler(data) {
         if (!this.orderPlaced) {
             return
         }
-        spinner.stop(true)
 
-        let message = ''
         let remainingSize = parseFloat(data.remaining_size)
-        let placeRemainderOrder = false
-
-        if (data.reason == 'filled') {
-            // size is not part of a filled order, only remaining_size. compare with last received
-            data.size = parseFloat(this.manager.getLastReceived().size) - parseFloat(data.remaining_size)
-            this.manager.updatePosition(data)
-            this.manager.removeOpenOrder()
-            this.manager.addFilled(data)
-            this.orderPlaced = false
-
-            message = `#${data.order_id}: `
-            // if position wasn't filled completely, open another order to do so
-            if (remainingSize !== 0) {
-                message += ` Partial fill. ${remainingSize} remaining.\n`
-                // placeRemainderOrder = true
-            }
-            message += `filled ${data.side} ${data.size} @ $${data.price}.\n`
-        } else if (data.reason == 'canceled') {
-            this.manager.removeOpenOrder()
-            if (data.side == 'buy') { 
-                this.manager.cancelPosition()
-            }
-            message = `#${data.order_id}: cancelled ${data.side} ${remainingSize} @ $${data.price}.\n`
-            // try to place another sell order
-            placeRemainderOrder = data.side == 'sell' && this.manager.getPosition()
-        }
-
-        if (placeRemainderOrder) {
-            message += "Placing an immediate order to fill remaining size.\n"
+        if (
+            (data.reason == 'canceled' && data.side == 'sell') ||
+            (data.reason == 'filled' && data.side == 'sell' && remainingSize !== 0)
+        ) {
+            console.log(`>> #${data.order} ${data.reason} ${data.side} w/ remaining ${remainingSize} ${this.options.product} @ $${data.price}.`)
+            console.log(`>> Placing an immediate order to fill remaining size.\n`)
             this.placeOrder({
                 side: data.side,
                 size: remainingSize,
-                price: data.side == 'sell' ? CandleProvider.state().best_ask : CandleProvider.state().best_bid,
+                price: CandleProvider.state().best_ask, //for now only sells open new orders
                 post_only: true,
                 time_in_force: 'GTT',
                 cancel_after: 'min'
             })
         }
 
-        // log and notify
-        if (message) {
-            console.log(`>> ${message}`)
-            notifier.notify({
-                title: 'JACT',
-                message: message
-            });
-        }
-
-        // show this after the other stuff
-        if (data.side == 'sell' && remainingSize == 0 && data.reason == 'filled') {
+        if (remainingSize == 0 && data.reason == 'filled') {
+            this.orderPlaced = false
             console.log(this.manager.info())
             console.log('\n')
         }

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -9,9 +9,7 @@ let Spinner = require('cli-spinner').Spinner
 let spinner = new Spinner('waiting... %s')
 spinner.setSpinnerString(0);
 
-// @todo maybe use 'match' event to manager.updatePosition() to split up logic
 // @todo need better error handling and logging
-// @todo orderPlaced is not always working
 class TraderBot {
     constructor({
         strategy,
@@ -107,16 +105,14 @@ class TraderBot {
             return
         }
 
-        let params = {
+        this.placeOrder({
             side: 'buy',
             size: this.manager.getOrderSize(CandleProvider.state().best_bid),
             price: CandleProvider.state().best_bid,
             post_only: true,
             time_in_force: 'GTT',
             cancel_after: 'min'
-        }
-
-        this.placeOrder(params)
+        })
     }
 
     /**

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -78,13 +78,17 @@ class TraderBot {
      * @return void
      */
     stopLosses() {
+        let openOrder = this.manager.getOpen()
+        if (openOrder) {
+            this.cancelOrder(openOrder.order_id)
+        }
+
         this.placeOrder({
             side: 'sell',
-            size: this.manager.getPosition().size,
+            size: this.manager.getPosition().remaining_size,
             type: 'market',
             product_id: this.options.product
         })
-        this.manager.closePosition()
     }
 
     /**
@@ -161,11 +165,6 @@ class TraderBot {
                 if (data.message) {
                     throw new Error(data.message)
                 }
-                if (data.status == 'rejected' && this.manager.getPosition()) {
-                    // rejected LONG orders out of sync with position in the manager so cancel any open position
-                    // this.manager.resetPosition()
-                    // @deprecated
-                }
             } catch (err) {
                 this.orderPlaced = false
                 console.log(`>> ${err}\n`)
@@ -186,24 +185,23 @@ class TraderBot {
      * 
      * @param {String} orderId 
      */
-    // cancelOrder(orderId) {
-    //     // @todo only if there's an open order
+    cancelOrder(orderId) {
+        async function cancelOrderAsync(id) {
+            try {
+                const data = await gdax.cancelOrder(id).catch(err => { throw new Error(err) })
+                if (data.message) {
+                    throw new Error(data.message)
+                }
+                this.orderPlaced = false
+                this.removeOpen(id)
+            } catch (err) {
+                this.orderPlaced = false
+                console.log(`>> ${err}\n`)
+            }
+        }
 
-    //     async function cancelOrderAsync(id) {
-    //         try {
-    //             const data = await gdax[opts.side](opts).catch(err => { throw new Error(err) })
-    //             if (data.message) {
-    //                 throw new Error(data.message)
-    //             }
-    //             this.orderPlaced = false
-    //         } catch (err) {
-    //             this.orderPlaced = false
-    //             console.log(`>> ${err}\n`)
-    //         }
-    //     }
-
-    //     cancelOrderAsync(orderId)
-    // }
+        cancelOrderAsync(orderId)
+    }
 
     /**
      * ticker update

--- a/lib/strategies/rsi.js
+++ b/lib/strategies/rsi.js
@@ -1,13 +1,18 @@
 const tiRsi = require('technicalindicators').RSI
 const HistoricDataProvider = require('../HistoricDataProvider')
+const cloneDeep = require('lodash/cloneDeep')
 
 const defaults = {
     values: [],
     period: 14
 }
 
-const RSI = () => {
-    let rsiInput = Object.assign({}, defaults, { values: HistoricDataProvider.get().map(value => value[4])})
+module.exports = () => {
+    let rsiInput = cloneDeep(defaults)
+    HistoricDataProvider.get().forEach(candle => {
+        rsiInput.values.push(candle[4])
+    })
+
     let rsi = tiRsi.calculate(rsiInput)
         .filter(values => values)
     let currentRsi = rsi[rsi.length - 1]
@@ -18,8 +23,4 @@ const RSI = () => {
     } else if (currentRsi > 70 && currentRsi < lastRsi) {
         return 'SHORT'
     }
-
-    return null
 }
-
-module.exports = RSI

--- a/lib/strategies/slow-stochastic.js
+++ b/lib/strategies/slow-stochastic.js
@@ -11,9 +11,18 @@ const defaults = {
     signalPeriod: 3
 }
 
-const SlowStochastic = () => {
+const logger = (data) => {
+    console.log(data)
+}
+
+const SlowStochastic = (showLog = false) => {
+    let log = showLog ? logger : () => {}
     let stochInput = cloneDeep(defaults)
-    HistoricDataProvider.get().forEach(candle => {
+    let data = HistoricDataProvider.get()
+    data.forEach(candle => {
+        if (!candle) {
+            return
+        }
         stochInput.high.push(candle[2])
         stochInput.low.push(candle[1])
         stochInput.close.push(candle[4])
@@ -22,8 +31,7 @@ const SlowStochastic = () => {
     let kd = stoch.calculate(stochInput).filter(values => values.d && values.k)
 
     let smoothK = sma.calculate({ values: kd.map(input => input.k), period: 3 })
-    let smoothD = sma.calculate({ values: kd.map(input => input.d), period: 3 })
-    let smoothStoch = []
+    let smoothD = sma.calculate({ values: smoothK.map(input => input), period: 3 })
 
     let currentK = smoothK[smoothK.length - 1]
     let currentD = smoothD[smoothD.length - 1]
@@ -31,9 +39,14 @@ const SlowStochastic = () => {
     let lastK = smoothK[smoothK.length - 2]
     let lastD = smoothD[smoothD.length - 2]
 
-    if (currentK > 50 && lastK < 50) {
+    // console.log(`currK: ${currentK}`)
+    // console.log(`prevK: ${lastK}`)
+    // console.log(`currD: ${currentD}`)
+    // console.log(`prevD: ${lastD}`)
+
+    if (currentK > 50 && lastK <= 50) {
         return 'LONG'
-    } else if (currentK < 50 && lastK > 50) {
+    } else if (currentK < 50 && lastK >= 50) {
         return 'SHORT'
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3267,7 +3267,7 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -3401,7 +3401,7 @@
                 "stringstream": "0.0.5",
                 "tough-cookie": "2.3.3",
                 "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "uuid": "3.2.1"
               }
             },
             "ws": {
@@ -3613,11 +3613,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-    },
-    "growly": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -4044,7 +4039,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -4499,17 +4495,6 @@
       "version": "2.0.0-alpha.9",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0-alpha.9.tgz",
       "integrity": "sha512-I7wP1QkmBNX1mt4BS5zyLRTegl5Ii+MSalpfFefn+EZFrGVsdfCvLTKt9eHkNlU4phKgp3tqLWW8VXDcCm9m9w=="
-    },
-    "node-notifier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
-      "requires": {
-        "growly": "1.3.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
-      }
     },
     "node.bittrex.api": {
       "version": "0.5.1",
@@ -5272,7 +5257,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "form-data": {
@@ -5331,7 +5316,8 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -5404,11 +5390,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -5922,9 +5903,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -5972,6 +5953,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "js-yaml": "^3.10.0",
     "lodash": "^4.17.4",
     "moment": "^2.20.1",
-    "node-notifier": "^5.2.1",
     "regression": "^2.0.1",
     "technicalindicators": "^1.0.21",
+    "uuid": "^3.2.1",
     "ws": "^4.0.0"
   },
   "devDependencies": {

--- a/sample.config.yaml
+++ b/sample.config.yaml
@@ -1,6 +1,7 @@
 
 # REQUIRED:
 # GDAX Authentication
+# =====================================
 gdax_auth:
     key: someKey
     secret: someSecret
@@ -10,26 +11,30 @@ gdax_auth:
 # filename of your strategy file OR of an already provided strategy the .js ext is optional
 # the bot will always look relative to the ./lib/strategies directory
 # ex: my-strategy, bestStrategy.js, macd, rsi
+# =====================================
 strategy: macd
 
 # REQUIRED:
 # trade/analyze interval in seconds
 # options: [60, 300, 900, 3600, 21600, 86400]
+# =====================================
 granularity: 60
 
 # REQUIRED: 
 # product to trade
 # options: [LTC-USD, BTC-USD, ETH-USD]
+# =====================================
 product: LTC-USD
 
 # REQUIRED:
 # create a stop loss of the provided percentage.
+# =====================================
 stopLoss: .05
 
 # OPTIONAL:
 # GDAX Authentication for SANDBOX environment
 # MUST be set if `sandbox: true`
-#
+# =====================================
 # gdax_sandbox_auth:
 #     key: someKey
 #     secret: someSecret
@@ -37,18 +42,21 @@ stopLoss: .05
 
 # OPTIONAL:
 # Run bot in a test environment
-#
+# =====================================
 # sandbox: true
 
 # OPTIONAL:
 # Maximum trading funds allowed, defaults to 95% wallet amount (to leave room for fees)
 # ** some trades will not succeed if the trade size is too small, don't set maxFunds too low
-#
+# =====================================
 # maxFunds: 100
 
 # OPTIONAL:
 # Dates for backtesting. if end_date is not set, today's date will be used
-# format must be ISO8601. ex: 2018-02-04T12:00:00Z
+# format must be ISO8601
+# or provide the 'period' option: day, week, month, year
+# =====================================
 # backtest: 
-#     start_date: null
+#     start_date: 2018-02-10T00:00:00Z
 #     end_date: null
+#     slippage: .2


### PR DESCRIPTION
- Portfolio stats are handled in a more sane fashion
- net and percentage gains/losses may actually be calculated correctly (finally)
- position is no longer opened or updated until its dependent order is matched
    - moved this logic to the 'match' event in the feed handlers
- add slippage option to the backtest results
- calculate avgLoss and avgWins
- fixed incorrect slow-stochastic calculation
- CandleProvider resets itself every `config.granularity` seconds (candle lows & highs were never reset causing calculations to flatten out overtime)