### PR TITLE
Backtest extend trader

### DIFF
--- a/lib/BacktestBot.js
+++ b/lib/BacktestBot.js
@@ -45,7 +45,6 @@ class BacktestBot extends TraderBot {
         let endChunkDate = moment(this.startMoment).add(this.chunkSize * this.options.granularity, 'seconds')
         let firstChunk = await this.getDataChunk(this.startMoment, endChunkDate)
         BacktestDataProvider.append(firstChunk)
-        this.updateListener()
         this.trade()
     }
 
@@ -149,21 +148,13 @@ class BacktestBot extends TraderBot {
     }
 
     /**
-     * Override traderBot matchHandler to not be async
-     * 
-     * @param {Object} data 
-     */
-    matchHandler(data) {
-        this.manager.updatePosition(data)
-    }
-
-    /**
      * open a position, update, fill
      * 
      * @return void
      */
     longPosition() {
-        if (this.manager.getPosition()) {
+        let lastTrade = this.manager.getLastFilled()
+        if (lastTrade && lastTrade.side == 'buy') {
             return
         }
 
@@ -171,14 +162,10 @@ class BacktestBot extends TraderBot {
         let slippage = this.getSlippage()
         let signaledClose = BacktestDataProvider.current()[4]
         let bestBid = signaledClose + (signaledClose * slippage)
-        this.signaledBuyPrice = signaledClose
-        let id = uuid()
         let params = {
-            maker_order_id: id,
-            order_id: id,
+            order_id: uuid(),
             side: 'buy',
             size: this.manager.getOrderSize(bestBid),
-            signal_buy_price: signaledClose,
             price: bestBid,
             remaining_size: 0,
             reason: 'filled',
@@ -197,19 +184,17 @@ class BacktestBot extends TraderBot {
      * @return void
      */
     shortPosition() {
-        let position = this.manager.getPosition()
-        if (!position) {
+        let lastTrade = this.manager.getLastFilled()
+        if (!lastTrade || lastTrade.side == 'sell') {
             return
         }
 
         // kind of makes a best-case scenario assumption here
         let best_ask = BacktestDataProvider.current()[4]
-        let id = uuid()
         let params = {
-            maker_order_id: id,
-            order_id: id,
+            order_id: uuid(),
             side: 'sell',
-            size: position.size,
+            size: lastTrade.size,
             price: best_ask,
             remaining_size: 0,
             reason: 'filled',

--- a/lib/BacktestBot.js
+++ b/lib/BacktestBot.js
@@ -6,33 +6,25 @@ const BacktestDataProvider = require('./BacktestDataProvider')
 
 const ProgressBar = require('ascii-progress');
 const uuid = require('uuid/v1')
+const TraderBot = require('./TraderBot')
 
-// @TODO add slippage
-class BacktestBot {
+class BacktestBot extends TraderBot {
     constructor({
         strategy,
         manager,
         options
     }) {
-        this.strategy = strategy
-        this.manager = manager
-        this.options = options
+        super({
+            strategy,
+            manager,
+            options
+        })
+
         this.startMoment = moment(this.options.backtest.startDate)
         this.endMoment = this.options.backtest.endDate ? moment(this.options.backtest.endDate) : moment()
         this.chunkSize = 350
         this.rateLimit = 3
         this.iterations = 0
-    }
-
-    /**
-     * wait for 1 second to avoid being rate limited by gdax api
-     * 
-     * @return {Promise}
-     */
-    async rateLimitResolver() {
-        return new Promise(resolve => {
-            setTimeout(resolve, 1000);
-        })
     }
 
     /**
@@ -53,8 +45,19 @@ class BacktestBot {
         let endChunkDate = moment(this.startMoment).add(this.chunkSize * this.options.granularity, 'seconds')
         let firstChunk = await this.getDataChunk(this.startMoment, endChunkDate)
         BacktestDataProvider.append(firstChunk)
-
+        this.updateListener()
         this.trade()
+    }
+
+    /**
+     * wait for 1 second to avoid being rate limited by gdax api
+     * 
+     * @return {Promise}
+     */
+    async rateLimitResolver() {
+        return new Promise(resolve => {
+            setTimeout(resolve, 1000);
+        })
     }
 
     /**
@@ -121,7 +124,7 @@ class BacktestBot {
             BacktestDataProvider.append(chunk)
             BacktestDataProvider.next()
             this.trade()
-        }   
+        }
     }
 
     /**
@@ -146,6 +149,15 @@ class BacktestBot {
     }
 
     /**
+     * Override traderBot matchHandler to not be async
+     * 
+     * @param {Object} data 
+     */
+    matchHandler(data) {
+        this.manager.updatePosition(data)
+    }
+
+    /**
      * open a position, update, fill
      * 
      * @return void
@@ -159,19 +171,22 @@ class BacktestBot {
         let slippage = this.getSlippage()
         let signaledClose = BacktestDataProvider.current()[4]
         let bestBid = signaledClose + (signaledClose * slippage)
-
+        this.signaledBuyPrice = signaledClose
+        let id = uuid()
         let params = {
-            order_id: uuid(), // mock an id for the order
+            maker_order_id: id,
+            order_id: id,
             side: 'buy',
             size: this.manager.getOrderSize(bestBid),
+            signal_buy_price: signaledClose,
             price: bestBid,
             remaining_size: 0,
-            reason: 'filled'
+            reason: 'filled',
+            time: moment().seconds()
         }
 
         // mock the feed
         this.openHandler(params)
-        params.signal_buy_price = signaledClose
         this.matchHandler(params)
         this.doneHandler(params)
     }
@@ -186,16 +201,19 @@ class BacktestBot {
         if (!position) {
             return
         }
-        
+
         // kind of makes a best-case scenario assumption here
         let best_ask = BacktestDataProvider.current()[4]
+        let id = uuid()
         let params = {
-            order_id: uuid(),
+            maker_order_id: id,
+            order_id: id,
             side: 'sell',
             size: position.size,
             price: best_ask,
             remaining_size: 0,
-            reason: 'filled'
+            reason: 'filled',
+            time: moment().seconds()
         }
 
         // mock the feed
@@ -211,65 +229,18 @@ class BacktestBot {
      */
     stopTrading() {
         this.progress.clear()
-        // end on a sell so we can see more reliable percentage
-        if (this.manager.getPosition()) {
-            BacktestDataProvider.previous()
-            this.shortPosition()
-        }
-        console.log('>> Backtest complete.\n')
-        console.log(this.manager.info())
-        console.log('\n')
-        process.exit()
-    }
-
-    /**
-     * Order open on book
-     * The order is now open on the order book. This message will only be sent for orders which are not fully filled immediately.remaining_size will indicate how much of the order is unfilled and going on the book.
-     * 
-     * @param {*} data 
-     */
-    openHandler(data) {
-        this.manager.addOpen(data)
-    }
-
-    /**
-     * When a trade is matched(exchanged)
-     */
-    matchHandler(data) {
-
-        if (this.manager.getPosition()) {
-            this.manager.updatePosition(data)
-        } else {
-            this.manager.openPosition(data)
-        }
-
-        // remove a specific order by id
-        data.maker_order_id = data.order_id
-        this.manager.removeOpen(data.maker_order_id)
-        this.manager.addFilled(data)
-    }
-
-    /**
-     * Order has been completed from the books
-     * Sent for all orders for which there was a received message
-     * 
-     * @param {*} data 
-     */
-    doneHandler(data) {
-        let remainingSize = parseFloat(data.remaining_size)
-        if (
-            (data.reason == 'canceled' && data.side == 'sell') ||
-            (data.reason == 'filled' && data.side == 'sell' && remainingSize !== 0)
-        ) {
-            this.placeOrder({
-                side: data.side,
-                size: remainingSize,
-                price: BacktestDataProvider.state().best_ask, //for now only sells open new orders
-                post_only: true,
-                time_in_force: 'GTT',
-                cancel_after: 'min'
-            })
-        }
+        let self = this
+        setInterval(function() {
+            if (this.processing) {
+                return
+            }
+            console.log('>> Backtest complete.\n')
+            console.log(self.manager.info())
+            console.log('\n')
+            clearInterval(this)
+            process.exit()
+        }, 200)
     }
 }
+
 module.exports = BacktestBot

--- a/lib/BacktestBot.js
+++ b/lib/BacktestBot.js
@@ -162,12 +162,12 @@ class BacktestBot extends TraderBot {
         let slippage = this.getSlippage()
         let signaledClose = BacktestDataProvider.current()[4]
         let bestBid = signaledClose + (signaledClose * slippage)
+        this.signaledBuyPrice = signaledClose
         let params = {
             order_id: uuid(),
             side: 'buy',
             size: this.manager.getOrderSize(bestBid),
             price: bestBid,
-            remaining_size: 0,
             reason: 'filled',
             time: moment().seconds()
         }
@@ -196,7 +196,6 @@ class BacktestBot extends TraderBot {
             side: 'sell',
             size: lastTrade.size,
             price: best_ask,
-            remaining_size: 0,
             reason: 'filled',
             time: moment().seconds()
         }

--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -2,6 +2,18 @@ const find = require('lodash/find')
 const cloneDeep = require('lodash/cloneDeep')
 const remove = require('lodash/remove')
 
+let positionDefaults = {
+    size: null,
+    remaining_size: null,
+    signal_buy_price: null,
+    buy_price: null,
+    signal_sell_price: null,
+    sell_price: null,
+    net: null,
+    percent: null,
+    slippage: null
+}
+// @TODO a lot of partial sell orders messed up the position numbers. investigate
 class PortfolioManager {
     constructor(accounts, options) {
         this.usdAccount = find(accounts, { currency: options.product.split('-')[1] })
@@ -23,26 +35,50 @@ class PortfolioManager {
     }
 
     /**
-     * Update a position props
+     * made async because unsure if match events were coming faster than the ability to process them
+     * 
+     * @param {Object} data 
+     * @return {Promise}
+     */
+    async updatePositionAsync(data) {
+        return new Promise((resolve, reject) => {
+            this.updatePosition(data)
+            resolve({ message: 'updated' })
+        })
+    }
+
+    /**
+     * Update Position props on match
      * 
      * @param {Object} data 
      */
     updatePosition(data) {
         let size = parseFloat(data.size)
         let price = parseFloat(data.price)
+        
         if (data.side == 'sell') {
             if (!this.position.signal_sell_price) {
                 this.position.signal_sell_price = price
             }
-            let remainingSize = this.position.size - size
+
+            this.position.side = data.side
+            this.position.remaining_size = parseFloat(this.position.size) - size
             this.position.sell_price += price * size
-            this.position.remaining_size = remainingSize
-            if (remainingSize == 0) {
-                this.position.sell_price = this.position.sell_price / this.position.size
+
+            if (this.position.remaining_size == 0) {
                 this.completePosition()
-                return
             }
-            this.position.sell_price = this.position.sell_price / (this.position.size - remainingSize)
+        } else {
+            if (!this.position) {
+                this.openPosition(data)
+            }
+            if (!this.position.signal_buy_price) {
+                this.position.signal_buy_price = price
+            }
+            this.position.side = data.side
+            this.position.remaining_size = 0
+            this.position.buy_price = price
+            this.position.size = size
         }
     }
 
@@ -50,33 +86,25 @@ class PortfolioManager {
      * Open a position, a long order has been placed
      */
     openPosition(data) {
-        this.position = {
-            size: data.size,
-            remaining_size: data.size,
-            signal_buy_price: data.signal_buy_price,
-            buy_price: data.price, // @todo could change if adjusted long orders become allowed
-            signal_sell_price: null,
-            sell_price: 0,
-            net: 0,
-            percent: 0,
-            slippage: 0
-        }
+        this.position = cloneDeep(positionDefaults)
     }
 
     /**
      * Calculate final percentages and append to the filled positions
      * then reset the position
      * 
+     * @TODO re-run these numbers on last log. They got really thrown off somehow
      * @return void
      */
-    completePosition(isBacktest) {
+    completePosition() {
+        this.position.sell_price = this.position.sell_price / this.position.size
         this.position.net = ((this.position.sell_price * this.position.size) - (this.position.buy_price * this.position.size))
         this.position.percent = (this.position.sell_price / this.position.buy_price) - 1
         this.position.slippage = (((this.position.signal_sell_price / this.position.signal_buy_price) - 1) - this.position.percent) || 0
         this.completed.push(this.position)
         // @TODO fetch this from gdax again
         // update the account amount after complete positions
-        this.usdAccount.currency += this.position.net 
+        this.usdAccount.currency += this.position.net
         this.resetPosition()
     }
 
@@ -201,7 +229,6 @@ class PortfolioManager {
     /**
      * State of the account
      * 
-     * @todo add more stats
      * @return {Object}
      */
     info() {

--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -198,7 +198,7 @@ class PortfolioManager {
         let netAcc = null
         let wins = this.filled.reduce((acc, trade) => {
             if (trade.side == 'sell') {
-                netAcc += (lastBuy.price * lastBuy.size) - (trade.price * trade.size)
+                netAcc += (trade.price * trade.size) - (lastBuy.price * lastBuy.size)
                 sizeAcc += trade.size
                 if (sizeAcc == parseFloat(lastBuy.size) && netAcc > 0) {
                     acc.push({ net: netAcc, percent: netAcc / lastBuy.size })
@@ -235,7 +235,7 @@ class PortfolioManager {
         let losses = 0
         this.filled.forEach(trade => {
             if (trade.side == 'sell') {
-                netAcc += (lastBuy.price * lastBuy.size) - (trade.price * trade.size)
+                netAcc += (trade.price * trade.size) - (lastBuy.price * lastBuy.size)
                 sizeAcc += trade.size
                 if (sizeAcc == parseFloat(lastBuy.size) && netAcc < 0) {
                     losses++
@@ -257,6 +257,27 @@ class PortfolioManager {
      * @return {Number}
      */
     getAvgSlippage() {
+        // let netAcc = null
+        // let sizeAcc = null
+        // let lastBuy = null
+        // let avgSellPrice = null
+        // let slippage = 0
+        // let completed = 0
+        // this.filled.forEach(trade => {
+        //     if (trade.side == 'sell') {
+        //         netAcc += (lastBuy.price * lastBuy.size) - (trade.price * trade.size)
+        //         sizeAcc += trade.size
+        //         if (sizeAcc == parseFloat(lastBuy.size)) {
+        //             slippage += ((trade.price - lastBuy.price) / (lastBuy.price - lastBuy.signal_price) + (trade.signal_price - trade.price)) - 1
+        //             completed++
+        //         }
+        //     } else {
+        //         sizeAcc = netAcc = 0
+        //         lastBuy = trade
+        //     }
+        // })
+        // console.log(slippage)
+        // return slippage / completed
         // let completed = this.completed
         // return completed.reduce((acc, position) => acc += position.slippage, 0) / completed.length
     }
@@ -273,7 +294,7 @@ class PortfolioManager {
             totalTrades: this.getFilled().length,
             wins: completed.wins,
             losses: completed.losses,
-            avgSlippage: 0,//this.getAvgSlippage().toFixed(4),
+            avgSlippage: undefined,//this.getAvgSlippage().toFixed(4),
             avgWin: this.getAvgWin(),
             avgLoss: this.getAvgLoss(),
             netProfit: this.getTotals()

--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -1,125 +1,70 @@
 const find = require('lodash/find')
 const cloneDeep = require('lodash/cloneDeep')
 const remove = require('lodash/remove')
+const findLast = require('lodash/findLast')
 
-let positionDefaults = {
-    size: null,
-    remaining_size: null,
-    signal_buy_price: null,
-    buy_price: null,
-    signal_sell_price: null,
-    sell_price: null,
-    net: null,
-    percent: null,
-    slippage: null
-}
-// @TODO a lot of partial sell orders messed up the position numbers. investigate
 class PortfolioManager {
     constructor(accounts, options) {
         this.usdAccount = find(accounts, { currency: options.product.split('-')[1] })
         this.assetAcount = find(accounts, { currency: options.product.split('-')[0] })
         this.options = options
 
-        this.position = null
-        this.completed = []
         this.open = []
         this.filled = []
     }
 
+    /**
+     * Add a filled order
+     * @param {Object} data 
+     * @return void
+     */
     addFilled(data) {
         this.filled.push(data)
     }
 
+    /**
+     * get all the filled orders
+     * @return {Array}
+     */
     getFilled() {
         return cloneDeep(this.filled)
     }
 
     /**
-     * made async because unsure if match events were coming faster than the ability to process them
-     * 
-     * @param {Object} data 
-     * @return {Promise}
+     * get the last filled order
+     * @return {Object}
      */
-    async updatePositionAsync(data) {
-        return new Promise((resolve, reject) => {
-            this.updatePosition(data)
-            resolve({ message: 'updated' })
-        })
+    getLastFilled() {
+        return this.filled[this.filled.length - 1]
     }
 
     /**
-     * Update Position props on match
-     * 
-     * @param {Object} data 
+     * get the last filled buy
+     * @return {Object}
      */
-    updatePosition(data) {
-        let size = parseFloat(data.size)
-        let price = parseFloat(data.price)
-        
-        if (data.side == 'sell') {
-            if (!this.position.signal_sell_price) {
-                this.position.signal_sell_price = price
-            }
+    getLastBuy() {
+        return findLast(this.filled, { side: 'buy' })
+    }
 
-            this.position.side = data.side
-            this.position.remaining_size = parseFloat(this.position.size) - size
-            this.position.sell_price += price * size
-
-            if (this.position.remaining_size == 0) {
-                this.completePosition()
-            }
-        } else {
-            if (!this.position) {
-                this.openPosition(data)
-            }
-            if (!this.position.signal_buy_price) {
-                this.position.signal_buy_price = price
-            }
-            this.position.side = data.side
-            this.position.remaining_size = 0
-            this.position.buy_price = price
-            this.position.size = size
+    /**
+     * get the current position size
+     * @return {Number}
+     */
+    getCurrentRemainingPositionSize() {
+        if (!this.filled.length) {
+            return 0
         }
-    }
 
-    /**
-     * Open a position, a long order has been placed
-     */
-    openPosition(data) {
-        this.position = cloneDeep(positionDefaults)
-    }
-
-    /**
-     * Calculate final percentages and append to the filled positions
-     * then reset the position
-     * 
-     * @TODO re-run these numbers on last log. They got really thrown off somehow
-     * @return void
-     */
-    completePosition() {
-        this.position.sell_price = this.position.sell_price / this.position.size
-        this.position.net = ((this.position.sell_price * this.position.size) - (this.position.buy_price * this.position.size))
-        this.position.percent = (this.position.sell_price / this.position.buy_price) - 1
-        this.position.slippage = (((this.position.signal_sell_price / this.position.signal_buy_price) - 1) - this.position.percent) || 0
-        this.completed.push(this.position)
-        // @TODO fetch this from gdax again
-        // update the account amount after complete positions
-        this.usdAccount.currency += this.position.net
-        this.resetPosition()
-    }
-
-    /**
-     * Reset position stats
-     */
-    resetPosition() {
-        this.position = null
-    }
-
-    /**
-     * Get the current position
-     */
-    getPosition() {
-        return cloneDeep(this.position)
+        let partials = 0
+        for (let i = this.filled.length-1; i >= 0; i--) {
+            if (this.filled[i].side == 'buy' && !partials) {
+                return this.filled[i].size
+            } else if (this.filled[i].side == 'buy' && partials) {
+                return this.filled[i].size - partials
+            } else {
+                partials += this.filled[i].size
+            }
+        }
     }
 
     /**
@@ -161,11 +106,12 @@ class PortfolioManager {
      * @param {Number} price 
      */
     shouldTriggerStop(price) {
-        if (!this.position) {
+        let lastBuy = this.getLastBuy()
+        if (!this.getCurrentRemainingPositionSize()) {
             return false
         }
 
-        return price <= (this.position.buy_price - (this.options.stopLoss * this.position.buy_price))
+        return price <= (lastBuy.price - (this.options.stopLoss * lastBuy.price))
     }
 
     /**
@@ -184,9 +130,29 @@ class PortfolioManager {
      * Get the totals of the completed positions
      */
     getTotals() {
+        let lastBuy = null
+        let net = this.filled.reduce((acc, trade) => {
+            if (trade.side == 'buy') {
+                lastBuy = trade
+                return acc
+            } else {
+                return acc += (trade.price * trade.size) - (lastBuy.price * lastBuy.size)
+            }
+        }, 0)
+
+        lastBuy = null
+        let percent = this.filled.reduce((acc, trade) => {
+            if (trade.side == 'sell') {
+                return acc += (trade.price / lastBuy.price) - 1
+            }
+            if (trade.side == 'buy') {
+                lastBuy = trade
+                return acc
+            }
+        }, 0)
         return {
-            usd: this.completed.reduce((acc, position) => acc += position.net, 0).toFixed(4),
-            percent: this.completed.reduce((acc, position) => acc += position.percent, 0).toFixed(4),
+            usd: net.toFixed(4),
+            percent: percent.toFixed(4)
         }
     }
 
@@ -194,13 +160,32 @@ class PortfolioManager {
      * Get the average of all losing trades
      */
     getAvgLoss() {
-        let losses = this.completed.filter(position => position.net < 0)
+        let lastBuy = null
+        let sizeAcc = null
+        let netAcc = null
+        let losses = this.filled.reduce((acc, trade) => {
+            if (trade.side == 'sell') {
+                netAcc += (lastBuy.price * lastBuy.size) - (trade.price * trade.size)
+                sizeAcc += trade.size
+                if (sizeAcc == parseFloat(lastBuy.size) && netAcc < 0) {
+                    acc.push({net: netAcc, percent: netAcc / lastBuy.size})
+                    return acc
+                }
+                return acc
+            } else {
+                sizeAcc = netAcc = 0
+                lastBuy = trade
+                return acc
+            }
+        }, [])
+        
         if (!losses.length) {
             return {}
         }
+
         return {
-            usd: (losses.reduce((acc, position) => acc += position.net, 0) / losses.length).toFixed(4),
-            percent: (losses.reduce((acc, position) => acc += position.percent , 0) / losses.length).toFixed(4)
+            usd: (losses.reduce((acc, loss) => acc += loss.net, 0) / losses.length).toFixed(4),
+            percent: (losses.reduce((acc, loss) => acc += loss.percent, 0) / losses.length).toFixed(4)
         }
     }
 
@@ -208,22 +193,72 @@ class PortfolioManager {
      * Get the average of all winning trades
      */
     getAvgWin() {
-        let wins = this.completed.filter(position => position.net >= 0)
+        let lastBuy = null
+        let sizeAcc = null
+        let netAcc = null
+        let wins = this.filled.reduce((acc, trade) => {
+            if (trade.side == 'sell') {
+                netAcc += (lastBuy.price * lastBuy.size) - (trade.price * trade.size)
+                sizeAcc += trade.size
+                if (sizeAcc == parseFloat(lastBuy.size) && netAcc > 0) {
+                    acc.push({ net: netAcc, percent: netAcc / lastBuy.size })
+                    return acc
+                }
+                return acc
+            } else {
+                sizeAcc = netAcc = 0
+                lastBuy = trade
+                return acc
+            }
+        }, [])
+
         if (!wins.length) {
             return {}
         }
+
         return {
-            usd: (wins.reduce((acc, position) => acc += position.net, 0) / wins.length).toFixed(4),
-            percent: (wins.reduce((acc, position) => acc += position.percent, 0) / wins.length).toFixed(4)
+            usd: (wins.reduce((acc, win) => acc += win.net, 0) / wins.length).toFixed(4),
+            percent: (wins.reduce((acc, win) => acc += win.percent, 0) / wins.length).toFixed(4)
         }
     }
 
     /**
+     * Get completed win & loss counts
+     * 
+     * @return {Object}
+     */
+    getCompleted() {
+        let netAcc = null
+        let sizeAcc = null
+        let lastBuy = null
+        let wins = 0
+        let losses = 0
+        this.filled.forEach(trade => {
+            if (trade.side == 'sell') {
+                netAcc += (lastBuy.price * lastBuy.size) - (trade.price * trade.size)
+                sizeAcc += trade.size
+                if (sizeAcc == parseFloat(lastBuy.size) && netAcc < 0) {
+                    losses++
+                } else if (sizeAcc == parseFloat(lastBuy.size) && netAcc > 0) {
+                    wins++
+                }
+            } else {
+                sizeAcc = netAcc = 0
+                lastBuy = trade
+            }
+        })
+        return { wins, losses }
+    }
+
+    /**
      * Calculate the average slippage of all orders
+     * 
+     * @TODO figure out how to calculate this now that we have no buy signal price
+     * @return {Number}
      */
     getAvgSlippage() {
-        let completed = this.completed
-        return completed.reduce((acc, position) => acc += position.slippage, 0) / completed.length
+        // let completed = this.completed
+        // return completed.reduce((acc, position) => acc += position.slippage, 0) / completed.length
     }
 
     /**
@@ -232,12 +267,13 @@ class PortfolioManager {
      * @return {Object}
      */
     info() {
+        let completed = this.getCompleted()
         return {
-            currentPosition: this.getPosition(),
+            lastTrade: this.getLastFilled(),
             totalTrades: this.getFilled().length,
-            wins: this.completed.filter(position => position.net >= 0).length,
-            losses: this.completed.filter(position => position.net < 0).length,
-            avgSlippage: this.getAvgSlippage().toFixed(4),
+            wins: completed.wins,
+            losses: completed.losses,
+            avgSlippage: 0,//this.getAvgSlippage().toFixed(4),
             avgWin: this.getAvgWin(),
             avgLoss: this.getAvgLoss(),
             netProfit: this.getTotals()

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -9,9 +9,6 @@ let Spinner = require('cli-spinner').Spinner
 let spinner = new Spinner('waiting... %s')
 spinner.setSpinnerString(0);
 
-const EventEmitter = require('events').EventEmitter;
-const matchEmitter = new EventEmitter();
-
 // @TODO need better error handling and logging
 class TraderBot {
     constructor({
@@ -25,13 +22,9 @@ class TraderBot {
 
         this.tradeInterval = null
 
-        this.updates = []
-        this.processingMatches = false
-
         this.signaledBuyPrice = null
         this.isFeedHot = false
         this.stopLossTriggered = false
-        this.completeAfterProcess = false
     }
 
     /**
@@ -57,7 +50,6 @@ class TraderBot {
         FeedService.subscribe('match', this.matchHandler.bind(this))
         FeedService.subscribe('done', this.doneHandler.bind(this))
         spinner.start()
-        this.updateListener()
         this.trade()
     }
 
@@ -97,6 +89,12 @@ class TraderBot {
      * @return void
      */
     stopLosses() {
+        let currentPosition = this.manager.getCurrentPositionSize()
+        if (currentPosition) {
+            this.logger('>> Signal STOP LOSS but no position to sell.')
+            return
+        }
+
         this.stopLossTriggered = true
         let openOrder = this.manager.getOpen()
         if (openOrder) {
@@ -105,7 +103,7 @@ class TraderBot {
 
         this.placeOrder({
             side: 'sell',
-            size: this.manager.getPosition().remaining_size,
+            size: currentPosition,
             type: 'market',
             product_id: this.options.product
         })
@@ -121,7 +119,7 @@ class TraderBot {
             this.logger(`>> Signal SHORT, but the feed is still processing the last signal.\n`)
         }
 
-        if (this.manager.getPosition()) {
+        if (this.manager.getCurrentPositionSize()) {
             this.logger('>> Signal LONG but already long.\n')
             return
         }
@@ -149,15 +147,15 @@ class TraderBot {
             this.logger(`>> Signal SHORT, but the feed is still processing the last signal.\n`)
         }
 
-        let position = this.manager.getPosition()
-        if (!position) {
+        let positionSize = this.manager.getCurrentPositionSize()
+        if (!positionSize) {
             this.logger('>> Signal SHORT but nothing to short.\n')
             return
         }
         
         this.placeOrder({
             side: 'sell',
-            size: position.size,
+            size: positionSize,
             price: CandleProvider.state().best_ask,
             post_only: true,
             time_in_force: 'GTT',
@@ -222,7 +220,7 @@ class TraderBot {
      * Order open on book
      * The order is now open on the order book. This message will only be sent for orders which are not fully filled immediately.remaining_size will indicate how much of the order is unfilled and going on the book.
      * 
-     * @param {*} data 
+     * @param {Object} data 
      */
     openHandler(data) {
         this.manager.addOpen(data)
@@ -231,69 +229,22 @@ class TraderBot {
     }
 
     /**
-     * Queue data to be processed sequentially and emit a match event
-     * 
-     * @param {Object} data 
-     * @return false
-     */
-    queueMatches(data) {
-        this.updates.push(data)
-        matchEmitter.emit('match');
-    }
-
-    /**
-     * Process an array of position updates asynchronously
-     * 
-     * @param {Array} updates 
-     * @return void
-     */
-    async processMatches(updates) {
-        if (this.processingMatches) {
-            return
-        }
-        this.processingMatches = true
-        for (const match of updates) {
-            await this.manager.updatePosition(match)
-            this.updates.shift()
-            this.logger(`>> #${match.maker_order_id}: filled. ${moment(match.time).toISOString()}`)
-            this.manager.removeOpen(match.maker_order_id)
-            this.manager.addFilled(match)
-        }
-        this.processingMatches = false
-    }
-
-    /**
-     * listen for an update event to kick off processing
-     * 
-     * @return void
-     */
-    updateListener() {
-        matchEmitter.on('match', () => {
-            this.processMatches(this.updates)
-        })
-    }
-
-    /**
      * When a trade is matched(exchanged)
+     * 
+     * @param {Object} data
      */
     matchHandler(data) {
-        this.queueMatches(data)
+        this.manager.addFilled(data)
     }
 
     /**
      * Order has been completed from the books
      * Sent for all orders for which there was a received message
      * 
-     * @TODO this needs to be async too because it depends on position data
-     * @param {*} data 
+     * @param {Object} data 
      */
     doneHandler(data) {
-        // if any order canceled, remove the open
-        if (data.reason == 'canceled') {
-            this.manager.removeOpen(data.order_id)
-            this.logger(`>> #${data.order_id}: canceled`)
-        }
-
+        this.manager.removeOpen(data.order_id)
         let remainingSize = parseFloat(data.remaining_size)
         let bestBid = CandleProvider.state().best_bid
         this.logger(`>> #${data.order_id} ${data.reason} ${data.side} w/ remaining ${remainingSize} ${this.options.product} @ $${data.price}.`)
@@ -309,16 +260,12 @@ class TraderBot {
             })
             return
         }
-       
-        if (data.side == 'sell' && data.reason == 'filled' && remainingSize == 0) {
-            this.isFeedHot = false
-            this.logger(this.manager.info())
-            this.logger('\n')
-            spinner.start()
-        }
 
-        // if any order filled, show in log, feed is not hot
-        if (data.side == 'buy' && data.reason == 'filled') {
+        // show info, feed is no longer hot, wait for next signal
+        if (
+            (data.side == 'buy' && data.reason == 'filled') ||
+            (data.side == 'sell' && data.reason == 'filled' && remainingSize == 0)
+        ) {
             this.isFeedHot = false
             this.logger(this.manager.info())
             this.logger('\n')
@@ -328,7 +275,6 @@ class TraderBot {
 
     /**
      * Abstract away some of the doneHandler replace order logic
-     * @TODO change so logic is based on position still has remaining_size
      * 
      * @param {*} data 
      * @return {Boolean}

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -23,6 +23,7 @@ class TraderBot {
         this.tradeInterval = null
 
         this.signaledBuyPrice = null
+        this.signaledSellPrice = null
         this.isFeedHot = false
         this.stopLossTriggered = false
     }
@@ -89,7 +90,7 @@ class TraderBot {
      * @return void
      */
     stopLosses() {
-        let currentPosition = this.manager.getCurrentPositionSize()
+        let currentPosition = this.manager.getCurrentRemainingPositionSize()
         if (currentPosition) {
             this.logger('>> Signal STOP LOSS but no position to sell.')
             return
@@ -119,7 +120,7 @@ class TraderBot {
             this.logger(`>> Signal SHORT, but the feed is still processing the last signal.\n`)
         }
 
-        if (this.manager.getCurrentPositionSize()) {
+        if (this.manager.getCurrentRemainingPositionSize()) {
             this.logger('>> Signal LONG but already long.\n')
             return
         }
@@ -147,16 +148,19 @@ class TraderBot {
             this.logger(`>> Signal SHORT, but the feed is still processing the last signal.\n`)
         }
 
-        let positionSize = this.manager.getCurrentPositionSize()
+        let positionSize = this.manager.getCurrentRemainingPositionSize()
         if (!positionSize) {
             this.logger('>> Signal SHORT but nothing to short.\n')
             return
         }
+
+        let bestAsk = CandleProvider.state().best_ask
+        this.signaledSellPrice = bestAsk
         
         this.placeOrder({
             side: 'sell',
             size: positionSize,
-            price: CandleProvider.state().best_ask,
+            price: bestAsk,
             post_only: true,
             time_in_force: 'GTT',
             cancel_after: 'min'
@@ -183,6 +187,7 @@ class TraderBot {
                 }
             } catch (err) {
                 this.signaledBuyPrice = null
+                this.signaledSellPrice = null
                 this.logger(`>> ${err}\n`)
             }
         }
@@ -234,6 +239,13 @@ class TraderBot {
      * @param {Object} data
      */
     matchHandler(data) {
+        // if (this.signaledBuyPrice) {
+        //     data.signal_price = this.signaledBuyPrice
+        // }
+
+        // if (this.signaledSellPrice) {
+        //     data.signal_price = this.signaledSellPrice
+        // }
         this.manager.addFilled(data)
     }
 
@@ -266,6 +278,8 @@ class TraderBot {
             (data.side == 'buy' && data.reason == 'filled') ||
             (data.side == 'sell' && data.reason == 'filled' && remainingSize == 0)
         ) {
+            this.signaledBuyPrice = null
+            this.signaledSellPrice = null
             this.isFeedHot = false
             this.logger(this.manager.info())
             this.logger('\n')

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -9,8 +9,10 @@ let Spinner = require('cli-spinner').Spinner
 let spinner = new Spinner('waiting... %s')
 spinner.setSpinnerString(0);
 
-// @todo need better error handling and logging
-// @todo add allowable slippage to replacement orders
+const EventEmitter = require('events').EventEmitter;
+const matchEmitter = new EventEmitter();
+
+// @TODO need better error handling and logging
 class TraderBot {
     constructor({
         strategy,
@@ -22,12 +24,25 @@ class TraderBot {
         this.options = options
 
         this.tradeInterval = null
-        this.orderPlaced = false
 
-        this.tickerUpdates = 0
-        this.tickerUpdatesMax = 10
+        this.updates = []
+        this.processingMatches = false
 
         this.signaledBuyPrice = null
+        this.isFeedHot = false
+        this.stopLossTriggered = false
+        this.completeAfterProcess = false
+    }
+
+    /**
+     * Nice logging wrapper
+     * 
+     * @param {Mixed} message 
+     */
+    logger(message) {
+        if (this.options.logging) {
+            console.log(message)
+        }
     }
 
     /**
@@ -37,11 +52,12 @@ class TraderBot {
      * @return void
      */
     startTrading() {
-        console.log(`>> Trading ${this.options.product} every ${this.options.granularity} seconds with ${this.options.strategy} strategy.\n`)
+        this.logger(`>> Trading ${this.options.product} every ${this.options.granularity} seconds with ${this.options.strategy} strategy.\n`)
         FeedService.subscribe('open', this.openHandler.bind(this))
         FeedService.subscribe('match', this.matchHandler.bind(this))
         FeedService.subscribe('done', this.doneHandler.bind(this))
         spinner.start()
+        this.updateListener()
         this.trade()
     }
 
@@ -57,17 +73,18 @@ class TraderBot {
         let signal = this.strategy.signal()
         if (this.manager.shouldTriggerStop(CandleProvider.state().close)) {
             spinner.stop(true)
-            console.log(moment().utc().format('M/D HH:mm:ss UTC') + '\n')
+            this.logger(moment().utc().format('M/D HH:mm:ss UTC') + '\n')
+            this.logger('>> Signal: STOP LOSS')
             this.stopLosses()
         } else if (signal == 'LONG') {
             spinner.stop(true)
-            console.log(moment().utc().format('M/D HH:mm:ss UTC') + '\n')
-            console.log('>> Signal: LONG')
+            this.logger(moment().utc().format('M/D HH:mm:ss UTC') + '\n')
+            this.logger('>> Signal: LONG')
             this.longPosition()
         } else if (signal == 'SHORT') {
             spinner.stop(true)
-            console.log(moment().utc().format('M/D HH:mm:ss UTC') + '\n')
-            console.log('>> Signal: SHORT')
+            this.logger(moment().utc().format('M/D HH:mm:ss UTC') + '\n')
+            this.logger('>> Signal: SHORT')
             this.shortPosition()
         }
 
@@ -80,6 +97,7 @@ class TraderBot {
      * @return void
      */
     stopLosses() {
+        this.stopLossTriggered = true
         let openOrder = this.manager.getOpen()
         if (openOrder) {
             this.cancelOrder(openOrder.order_id)
@@ -96,18 +114,15 @@ class TraderBot {
     /**
      * Open a position (buy)
      * 
-     * @TODO if re-selling a canceled position and signal LONG, cancel sell order, and wait for next SHORT signal
-     * // it seems this may already happen by happy accident
      * @return void
      */
     longPosition() {
-        if (this.manager.getOpen()) {
-            console.log(`>> Signal LONG, but there is an open order.\n`)
-            return
+        if (this.isFeedHot) {
+            this.logger(`>> Signal SHORT, but the feed is still processing the last signal.\n`)
         }
 
         if (this.manager.getPosition()) {
-            console.log('>> Signal LONG but already long.\n')
+            this.logger('>> Signal LONG but already long.\n')
             return
         }
 
@@ -130,14 +145,13 @@ class TraderBot {
      * @return void
      */
     shortPosition() {
-        if (this.manager.getOpen()) {
-            console.log(`>> Signal SHORT, but there is an open order.\n`)
-            return
+        if (this.isFeedHot) {
+            this.logger(`>> Signal SHORT, but the feed is still processing the last signal.\n`)
         }
 
         let position = this.manager.getPosition()
         if (!position) {
-            console.log('>> Signal SHORT but nothing to short.\n')
+            this.logger('>> Signal SHORT but nothing to short.\n')
             return
         }
         
@@ -159,21 +173,19 @@ class TraderBot {
      */
     placeOrder(options = {}) {
         if (!options.side || !options.size) {
-            console.log(`side: '${options.side}' and size: '${options.size}' are required. No order placed.`)
+            this.logger(`side: '${options.side}' and size: '${options.size}' are required. No order placed.`)
             return
         }
 
         async function orderAsync(opts) {
-            this.orderPlaced = true
             try {
                 const data = await gdax[opts.side](opts).catch(err => { throw new Error(err) })
                 if (data.message) {
                     throw new Error(data.message)
                 }
             } catch (err) {
-                this.orderPlaced = false
                 this.signaledBuyPrice = null
-                console.log(`>> ${err}\n`)
+                this.logger(`>> ${err}\n`)
             }
         }
 
@@ -187,7 +199,6 @@ class TraderBot {
     }
 
     /**
-     * @TODO Manually cancel an order
      * 
      * @param {String} orderId 
      */
@@ -198,11 +209,9 @@ class TraderBot {
                 if (data.message) {
                     throw new Error(data.message)
                 }
-                this.orderPlaced = false
                 this.removeOpen(id)
             } catch (err) {
-                this.orderPlaced = false
-                console.log(`>> ${err}\n`)
+                this.logger(`>> ${err}\n`)
             }
         }
 
@@ -216,82 +225,123 @@ class TraderBot {
      * @param {*} data 
      */
     openHandler(data) {
-        if (!this.orderPlaced) {
+        this.manager.addOpen(data)
+        this.isFeedHot = true
+        this.logger(`>> #${data.order_id}: open.`)
+    }
+
+    /**
+     * Queue data to be processed sequentially and emit a match event
+     * 
+     * @param {Object} data 
+     * @return false
+     */
+    queueMatches(data) {
+        this.updates.push(data)
+        matchEmitter.emit('match');
+    }
+
+    /**
+     * Process an array of position updates asynchronously
+     * 
+     * @param {Array} updates 
+     * @return void
+     */
+    async processMatches(updates) {
+        if (this.processingMatches) {
             return
         }
-        this.manager.addOpen(data)
-        console.log(`>> #${data.order_id}: open.`)
+        this.processingMatches = true
+        for (const match of updates) {
+            await this.manager.updatePosition(match)
+            this.updates.shift()
+            this.logger(`>> #${match.maker_order_id}: filled. ${moment(match.time).toISOString()}`)
+            this.manager.removeOpen(match.maker_order_id)
+            this.manager.addFilled(match)
+        }
+        this.processingMatches = false
+    }
+
+    /**
+     * listen for an update event to kick off processing
+     * 
+     * @return void
+     */
+    updateListener() {
+        matchEmitter.on('match', () => {
+            this.processMatches(this.updates)
+        })
     }
 
     /**
      * When a trade is matched(exchanged)
      */
     matchHandler(data) {
-        if (!this.orderPlaced) {
-            return
-        }
-
-        if (this.manager.getPosition()) {
-            this.manager.updatePosition(data)
-        } else {
-            data.signal_buy_price = this.signaledBuyPrice
-            this.manager.openPosition(data)
-            this.signaledBuyPrice = null
-        }
-
-        console.log(`>> #${data.maker_order_id}: filled.`)
-        this.manager.removeOpen(data.maker_order_id)
-        this.manager.addFilled(data)
+        this.queueMatches(data)
     }
 
     /**
      * Order has been completed from the books
      * Sent for all orders for which there was a received message
      * 
+     * @TODO this needs to be async too because it depends on position data
      * @param {*} data 
      */
     doneHandler(data) {
-        if (!this.orderPlaced) {
-            return
-        }
-
+        // if any order canceled, remove the open
         if (data.reason == 'canceled') {
             this.manager.removeOpen(data.order_id)
-            console.log(`>> #${data.order_id}: canceled`)
+            this.logger(`>> #${data.order_id}: canceled`)
         }
 
         let remainingSize = parseFloat(data.remaining_size)
-        if (this.shouldReplaceOrder(data)) {
-            console.log(`>> #${data.order_id} ${data.reason} ${data.side} w/ remaining ${remainingSize} ${this.options.product} @ $${data.price}.`)
-            console.log(`>> Placing an immediate order to fill remaining size.\n`)
+        let bestBid = CandleProvider.state().best_bid
+        this.logger(`>> #${data.order_id} ${data.reason} ${data.side} w/ remaining ${remainingSize} ${this.options.product} @ $${data.price}.`)
+        if (this.shouldReplaceOrder(data, bestBid)) {
+            this.logger(`>> Placing an immediate order to fill remaining size.\n`)
             this.placeOrder({
                 side: data.side,
-                size: parseFloat(data.remaining_size),
-                price: data.side == 'sell' ? CandleProvider.state().best_ask : CandleProvider.state().best_bid,
+                size: remainingSize,
+                price: data.side == 'sell' ? CandleProvider.state().best_ask : bestBid,
                 post_only: true,
                 time_in_force: 'GTT',
                 cancel_after: 'min'
             })
+            return
+        }
+       
+        if (data.side == 'sell' && data.reason == 'filled' && remainingSize == 0) {
+            this.isFeedHot = false
+            this.logger(this.manager.info())
+            this.logger('\n')
+            spinner.start()
         }
 
-        if (remainingSize == 0 && data.reason == 'filled') {
-            this.orderPlaced = false
-            console.log(this.manager.info())
-            console.log('\n')
+        // if any order filled, show in log, feed is not hot
+        if (data.side == 'buy' && data.reason == 'filled') {
+            this.isFeedHot = false
+            this.logger(this.manager.info())
+            this.logger('\n')
             spinner.start()
         }
     }
 
     /**
      * Abstract away some of the doneHandler replace order logic
+     * @TODO change so logic is based on position still has remaining_size
      * 
      * @param {*} data 
      * @return {Boolean}
      */
-    shouldReplaceOrder(data) {
+    shouldReplaceOrder(data, price) {
         let remainingSize = parseFloat(data.remaining_size)
-        let bidAllowed = this.manager.isBidAllowed(this.signaledBuyPrice, CandleProvider.state().best_bid)
-        return (data.reason == 'canceled' && data.side == 'sell') ||
+        let bidAllowed = this.manager.isBidAllowed(this.signaledBuyPrice, price)
+
+        if (data.reason == 'canceled' && data.side == 'buy' && !bidAllowed) {
+            this.logger('>> Max slippage won\'t allow a replacement order.\n')
+        }
+        return !this.stopLossTriggered &&
+            (data.reason == 'canceled' && data.side == 'sell') ||
             (data.reason == 'canceled' && data.side == 'buy' && bidAllowed) ||
             (data.reason == 'filled' && data.side == 'sell' && remainingSize !== 0)
     }


### PR DESCRIPTION
- backtest now extends the trading bot so that backtesting has more parity with the actual trader
- removed queueing for match updates because it caused other places to be out of sync and greatly increased run time logic
- little glitch fixes

*KNOWN ISSUE. PortfolioManager.info is not calculating totals correctly after sync change