### PR TITLE
remaining size too small to place further orders

### DIFF
--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -8,6 +8,14 @@ let account = null
 let filled = []
 let open = []
 
+const minimums = {
+    'LTC-USD': .1,
+    'ETH-USD': .01,
+    'BTC-USD': .001,
+}
+
+let minimumOrderSize = null
+
 /**
  * Add a filled order
  * @param {Object} data 
@@ -50,17 +58,26 @@ const getRemainingPositionSize = () => {
         return 0
     }
 
-    let partials = 0
+    let partialSells = 0
     for (let i = filled.length-1; i >= 0; i--) {
         let size = parseFloat(filled[i].size)
-        if (filled[i].side == 'buy' && !partials) {
+        if (filled[i].side == 'buy' && !partialSells) {
             return size
-        } else if (filled[i].side == 'buy' && partials) {
-            return size - partials
+        } else if (filled[i].side == 'buy' && partialSells) {
+            return size - partialSells < minimumOrderSize && size - partialSells > 0 ? minimumOrderSize : size - partialSells 
         } else {
-            partials += size
+            partialSells += size
         }
     }
+}
+
+/**
+ * Get the minimum for product
+ * 
+ * @return {Number}
+ */
+const getMinimumOrderSize = () => {
+    return minimumOrderSize
 }
 
 /**
@@ -103,7 +120,8 @@ const removeOpen = (id) => {
  */
 const shouldTriggerStop = (price) => {
     let lastBuy = getLastBuy()
-    if (!getRemainingPositionSize()) {
+    let position = getRemainingPositionSize()
+    if (!position || position < minimumOrderSize) {
         return false
     }
 
@@ -170,7 +188,7 @@ const getAvgLoss = () => {
             sizeAcc += tradeSize
             if (sizeAcc == buySize) {
                 priceAcc = priceAcc - (lastBuy.price * buySize)
-                if (priceAcc < 0) {
+                if (priceAcc < minimumOrderSize) {
                     acc.push({ net: priceAcc, percent: priceAcc / (lastBuy.price * buySize) })
                 }
             }
@@ -209,7 +227,7 @@ const getAvgWin = () => {
             sizeAcc += tradeSize
             if (sizeAcc == buySize) {
                 priceAcc = priceAcc - (lastBuy.price * buySize)
-                if (priceAcc >= 0) {
+                if (priceAcc >= minimumOrderSize) {
                     acc.push({ net: priceAcc, percent: priceAcc / (lastBuy.price * buySize) })
                 }
             }
@@ -250,7 +268,7 @@ const getCompleted = () => {
             sizeAcc += trade.size
             if (sizeAcc == parseFloat(lastBuy.size)) {
                 priceAcc = priceAcc - (lastBuy.price * lastBuy.size)
-                if (priceAcc >= 0) {
+                if (priceAcc >= minimumOrderSize) {
                     wins++
                 } else {
                     losses++
@@ -323,6 +341,7 @@ const setAccount = newAccount => {
     account = newAccount
     filled = []
     open = []
+    minimumOrderSize = minimums[config.get('product')]
 }
 
 module.exports = {
@@ -344,5 +363,6 @@ module.exports = {
     // getAvgSlippage,
     info,
     getOrderSize,
-    getFundingAmount
+    getFundingAmount,
+    getMinimumOrderSize
 }

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -106,7 +106,8 @@ class TraderBot {
      * @return void
      */
     longPosition() {
-        if (manager.getRemainingPositionSize()) {
+        let positionSize = manager.getRemainingPositionSize()
+        if (positionSize) {
             this.logger('>> Signal LONG but already long.\n')
             return
         }
@@ -262,9 +263,10 @@ class TraderBot {
         this.logger(`>> #${data.order_id} ${data.reason} ${data.side} w/ remaining ${remainingSize} ${config.get('product')} @ $${data.price}.`)
         if (this.shouldReplaceOrder(data, bestBid)) {
             this.logger(`>> Placing an immediate order to fill remaining size.\n`)
+            let minimumSize = manager.getMinimumOrderSize()
             this.placeOrder({
                 side: data.side,
-                size: remainingSize,
+                size: remainingSize < minimumSize ? minimumSize : remainingSize,
                 price: data.side == 'sell' ? CandleProvider.state().best_ask : bestBid,
                 post_only: true,
                 time_in_force: 'GTT',
@@ -308,7 +310,7 @@ class TraderBot {
         }
         return (data.reason == 'canceled' && data.side == 'sell') ||
             (data.reason == 'canceled' && data.side == 'buy' && bidAllowed) ||
-            (data.reason == 'filled' && data.side == 'sell' && remainingSize !== 0)
+            (data.reason == 'filled' && data.side == 'sell' && remainingSize > 0)
     }
 }
 

--- a/test/TraderBotTest.js
+++ b/test/TraderBotTest.js
@@ -251,3 +251,31 @@ test('shouldReplaceOrder', t => {
 	manager.isBidAllowed = () => false
 	t.falsy(trader.shouldReplaceOrder(cancelledBuy, 100))
 })
+
+test('perform order if remaining size is less than .1', t => {
+	let trader = t.context.trader
+	const manager = t.context.manager
+
+	let fills = [{
+		side: 'buy',
+		remaining_size: '1',
+		reason: 'filled'
+	},
+	{
+		side: 'sell',
+		remaining_size: '0.95',
+		reason: 'filled'
+	}]
+
+	fills.forEach(fill => manager.addFilled(fill))
+
+	trader.placeOrder = sinon.spy()
+	// if remaining size is less than .1 don't sell
+	trader.shortPosition()
+	t.falsy(trader.placeOrder.calledOnce)
+
+	// can buy if remaining position is greater than .1
+	trader.longPosition()
+	t.truthy(trader.placeOrder.calledOnce)
+
+})


### PR DESCRIPTION
https://github.com/kylerberry/JACT/issues/29

no solution is really ideal. the first solution throws off a lot of zero checks and complicates total calculations. The second solution also complicates calculations and introduces the possibility to sell the remainder at a loss. Opted for if a position > 0 and < minimumSize for that product, set the order size to the minimumSize. This still makes calculations a little weak, but will force the bot to completely sell off a position (and then some) before moving on.