### PR TITLE
better solution for remainder positions less than minimum order size

### DIFF
--- a/lib/PortfolioManager.js
+++ b/lib/PortfolioManager.js
@@ -7,6 +7,13 @@ const config = require('./ConfigProvider')
 let account = null
 let filled = []
 let open = []
+let minimumOrderSize = null
+
+const minimums = {
+    'LTC-USD' : .1,
+    'BTC-USD': .001,
+    'ETH-USD': .01,
+}
 
 /**
  * Add a filled order
@@ -43,24 +50,30 @@ const getLastBuy = () => {
 
 /**
  * get the current position size
+ * 
  * @return {Number}
  */
-const getRemainingPositionSize = () => {
+const getPositionSize = () => {
     if (!filled.length) {
         return 0
     }
 
-    let partials = 0
-    for (let i = filled.length-1; i >= 0; i--) {
-        let size = parseFloat(filled[i].size)
-        if (filled[i].side == 'buy' && !partials) {
-            return size
-        } else if (filled[i].side == 'buy' && partials) {
-            return size - partials
+    return filled.reduce((acc, trade) => {
+        if (trade.side == 'buy') {
+            return acc + parseFloat(trade.size)
         } else {
-            partials += size
+            return acc - parseFloat(trade.size)
         }
-    }
+    }, 0)
+}
+
+/**
+ * Get the minimum order size
+ * 
+ * @return {Number}
+ */
+const getMinimumOrderSize = () => {
+    return minimumOrderSize
 }
 
 /**
@@ -103,7 +116,7 @@ const removeOpen = (id) => {
  */
 const shouldTriggerStop = (price) => {
     let lastBuy = getLastBuy()
-    if (!getRemainingPositionSize()) {
+    if (getPositionSize() < getMinimumOrderSize()) {
         return false
     }
 
@@ -134,14 +147,14 @@ const getTotals = () => {
             lastBuy = trade
             return acc
         } else {
-            return acc += (trade.price * trade.size) - (lastBuy.price * lastBuy.size)
+            return acc + (trade.price * trade.size) - (lastBuy.price * lastBuy.size)
         }
     }, 0)
 
     lastBuy = null
     let percent = filled.reduce((acc, trade) => {
         if (trade.side == 'sell') {
-            return acc += (trade.price / lastBuy.price) - 1
+            return acc + (trade.price / lastBuy.price) - 1
         } else {
             lastBuy = trade
             return acc
@@ -323,6 +336,7 @@ const setAccount = newAccount => {
     account = newAccount
     filled = []
     open = []
+    minimumOrderSize = minimums[config.get('product')]
 }
 
 module.exports = {
@@ -331,7 +345,7 @@ module.exports = {
     getFilled,
     getLastFilled,
     getLastBuy,
-    getRemainingPositionSize,
+    getPositionSize,
     addOpen,
     getOpen,
     removeOpen,
@@ -344,5 +358,6 @@ module.exports = {
     // getAvgSlippage,
     info,
     getOrderSize,
-    getFundingAmount
+    getFundingAmount,
+    getMinimumOrderSize
 }

--- a/lib/TraderBot.js
+++ b/lib/TraderBot.js
@@ -80,8 +80,8 @@ class TraderBot {
      * @return void
      */
     stopLosses() {
-        let currentPosition = manager.getRemainingPositionSize()
-        if (!currentPosition) {
+        let currentPosition = manager.getPositionSize()
+        if (currentPosition < manager.getMinimumOrderSize()) {
             this.logger('>> Signal STOP LOSS but no position to sell.')
             return
         }
@@ -106,7 +106,9 @@ class TraderBot {
      * @return void
      */
     longPosition() {
-        if (manager.getRemainingPositionSize()) {
+        let positionSize = manager.getPositionSize()
+        let minimumSize = manager.getMinimumOrderSize()
+        if (positionSize >= minimumSize) {
             this.logger('>> Signal LONG but already long.\n')
             return
         }
@@ -130,8 +132,9 @@ class TraderBot {
      * @return void
      */
     shortPosition() {
-        let positionSize = manager.getRemainingPositionSize()
-        if (!positionSize) {
+        let positionSize = manager.getPositionSize()
+        let minimumSize = manager.getMinimumOrderSize()
+        if (positionSize < minimumSize) {
             this.logger('>> Signal SHORT but nothing to short.\n')
             return
         }
@@ -275,7 +278,7 @@ class TraderBot {
         // show info, wait for next signal
         if (
             (data.side == 'buy' && data.reason == 'filled') ||
-            (data.side == 'sell' && data.reason == 'filled' && remainingSize == 0)
+            (data.side == 'sell' && data.reason == 'filled' && remainingSize < manager.getMinimumOrderSize())
         ) {
             this.resetFlags()
             this.logger(manager.info())
@@ -302,13 +305,14 @@ class TraderBot {
     shouldReplaceOrder(data, price) {
         let remainingSize = parseFloat(data.remaining_size)
         let bidAllowed = manager.isBidAllowed(this.signaledBuyPrice, price)
+        let minimumSize = manager.getMinimumOrderSize()
 
         if (data.reason == 'canceled' && data.side == 'buy' && !bidAllowed) {
             this.logger('>> Max slippage won\'t allow a replacement order.\n')
         }
         return (data.reason == 'canceled' && data.side == 'sell') ||
             (data.reason == 'canceled' && data.side == 'buy' && bidAllowed) ||
-            (data.reason == 'filled' && data.side == 'sell' && remainingSize !== 0)
+            (data.reason == 'filled' && data.side == 'sell' && remainingSize >= minimumSize)
     }
 }
 

--- a/test/PortfolioManagerTest.js
+++ b/test/PortfolioManagerTest.js
@@ -118,7 +118,7 @@ test('avgLoss for partially filled trades', t => {
     t.is(losses.percent, '-0.1700')
 })
 
-test('getRemainingPositionSize', t => {
+test('getPositionSize', t => {
     let manager = t.context.manager
 
     manager.addFilled({
@@ -126,21 +126,21 @@ test('getRemainingPositionSize', t => {
         size: '1',
         price: '100'
     })
-    t.is(manager.getRemainingPositionSize(), 1)
+    t.is(manager.getPositionSize(), 1)
 
     manager.addFilled({
         side: 'sell',
         size: '.3',
         price: '110',
     })
-    t.is(manager.getRemainingPositionSize(), .7)
+    t.is(manager.getPositionSize(), .7)
 
     manager.addFilled({
         side: 'sell',
         size: '.7',
         price: '110',
     })
-    t.is(manager.getRemainingPositionSize(), 0)
+    t.is(manager.getPositionSize(), 0)
 })
 
 test('shouldTriggerStop', t => {


### PR DESCRIPTION
fix for https://github.com/kylerberry/JACT/issues/29

ok, i think this is a better solution. it may require some changes to the manger.info calculations, because the threshold for calculating a 'win' vs a 'loss' is changed.

instead of the bot trying to sell 100% of a position before moving on, it will sell until the remainder is < the minimum order size. this is different for each trading pair. e.g. (.1 for LTC, .01 for ETH). At this point it will allow purchasing to continue. Any remainders from previous sells will be appended onto subsequent sell orders.

I'll open an issue for the info calculation when i have a better idea of how it's been affected.